### PR TITLE
Add functionality to handle early meeting end status and update tray …

### DIFF
--- a/src/glowstatus.py
+++ b/src/glowstatus.py
@@ -48,7 +48,10 @@ class GlowStatusController:
                 govee.set_power("off")
                 return
         else:
-            if manual_status:
+            if manual_status == "meeting_ended_early":
+                govee.set_power("off")
+                return
+            elif manual_status:
                 status = manual_status
             else:
                 calendar = CalendarSync(SELECTED_CALENDAR_ID)
@@ -104,7 +107,11 @@ class GlowStatusController:
             calendar = CalendarSync(SELECTED_CALENDAR_ID)
             try:
                 manual_status = config.get("CURRENT_STATUS")
-                if manual_status:
+                if manual_status == "meeting_ended_early":
+                    govee.set_power("off")
+                    time.sleep(REFRESH_INTERVAL)
+                    continue
+                elif manual_status:
                     status = manual_status
                 else:
                     status, next_event_start = calendar.get_current_status(return_next_event_time=True)

--- a/src/tray_app.py
+++ b/src/tray_app.py
@@ -45,7 +45,15 @@ def main():
         glowstatus.update_now()
         update_tray_tooltip()
 
-    def clear_manual_status():
+    def set_end_meeting():
+        config = load_config()
+        config["CURRENT_STATUS"] = "meeting_ended_early"
+        save_config(config)
+        update_tray_tooltip()
+        glowstatus.update_now()
+        update_tray_tooltip()
+
+    def reset_state():
         config = load_config()
         if "CURRENT_STATUS" in config:
             del config["CURRENT_STATUS"]
@@ -71,10 +79,6 @@ def main():
 
     # --- App Setup ---
     config = load_config()
-    # Remove the following two lines to persist sync state:
-    # config["DISABLE_CALENDAR_SYNC"] = True
-    # save_config(config)
-
     app = QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
 
@@ -96,7 +100,8 @@ def main():
     manual_meeting = QAction("Set Status: In Meeting")
     manual_focus = QAction("Set Status: Focus")
     manual_available = QAction("Set Status: Available")
-    clear_override = QAction("Clear Manual Override")
+    manual_end_meeting = QAction("End Meeting (Turn Off Light Early)")
+    reset_override = QAction("Reset State")
     sync_toggle = QAction("Disable Sync" if sync_enabled[0] else "Enable Sync")
     quit_action = QAction("Quit")
 
@@ -105,7 +110,8 @@ def main():
     manual_meeting.triggered.connect(lambda: set_manual_status("in_meeting"))
     manual_focus.triggered.connect(lambda: set_manual_status("focus"))
     manual_available.triggered.connect(lambda: set_manual_status("available"))
-    clear_override.triggered.connect(clear_manual_status)
+    manual_end_meeting.triggered.connect(set_end_meeting)
+    reset_override.triggered.connect(reset_state)
     sync_toggle.triggered.connect(toggle_sync)
     quit_action.triggered.connect(lambda: (glowstatus.stop(), app.quit()))
 
@@ -115,7 +121,8 @@ def main():
     menu.addAction(manual_meeting)
     menu.addAction(manual_focus)
     menu.addAction(manual_available)
-    menu.addAction(clear_override)
+    menu.addAction(manual_end_meeting)
+    menu.addAction(reset_override)
     menu.addSeparator()
     menu.addAction(sync_toggle)
     menu.addSeparator()


### PR DESCRIPTION

This pull request introduces a new manual status, "meeting_ended_early," to enhance control over the status and light behavior in the application. It also refactors the tray menu to include new actions for managing the application state. Below is a summary of the most important changes grouped by theme.

### Enhancements to Status Handling:
* [`src/glowstatus.py`](diffhunk://#diff-e784283bb3fe34e780738c0e7977ae68eaf5b4447c162952095d1e1cdd380810L51-R54): Added logic to handle the new "meeting_ended_early" status in both `update_now` and `_run` methods, ensuring the light turns off immediately when this status is set. [[1]](diffhunk://#diff-e784283bb3fe34e780738c0e7977ae68eaf5b4447c162952095d1e1cdd380810L51-R54) [[2]](diffhunk://#diff-e784283bb3fe34e780738c0e7977ae68eaf5b4447c162952095d1e1cdd380810L107-R114)

### Tray Menu Updates:
* [`src/tray_app.py`](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL99-R104): Added a new action, "End Meeting (Turn Off Light Early)," to the tray menu, along with a corresponding `set_end_meeting` function to set the "meeting_ended_early" status. [[1]](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL99-R104) [[2]](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL108-R114)
* [`src/tray_app.py`](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL99-R104): Replaced the "Clear Manual Override" action with "Reset State," which removes the manual status and resets the application state. [[1]](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL99-R104) [[2]](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL108-R114) [[3]](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL118-R125)

### Code Cleanup:
* [`src/tray_app.py`](diffhunk://#diff-b6886b64a67529fffe531f4bfd5c9c27677296ccc1f29eefd0fec931c51ed13aL74-L77): Removed commented-out code related to persisting sync state for better readability and maintainability.