### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,5 +1,8 @@
 name: Windows Build and Chocolatey Package
 
+permissions:
+  contents: write
+
 # Security Features:
 # - Only repository owner/maintainers can trigger builds
 # - Google OAuth credentials stored securely in GitHub Secrets


### PR DESCRIPTION
Potential fix for [https://github.com/BitPadLabs/GlowStatus/security/code-scanning/3](https://github.com/BitPadLabs/GlowStatus/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow file to limit the GITHUB_TOKEN permissions to the least privilege necessary for this workflow. The best place to add this is at the top level, just below the `name:` and above the `on:` block, so that all jobs inherit these permissions—unless any job specifically requires more extensive write access (say for releases), in which case a job-level override may be needed. For most build-and-release workflows, the minimum necessary is `contents: read` for jobs that just read files or use the code, and `contents: write` if you are creating releases. In this case, uploading releases with softprops/action-gh-release requires `contents: write`. If the workflow needs to write pull requests or issues, those can be added (unlikely here).

The change: Insert a root-level `permissions:` block directly after the workflow name declaration and before the "on:" block, containing at least `contents: write`, which covers creating and uploading releases. This ensures no excess permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
