### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord-setup.yml
+++ b/.github/workflows/discord-setup.yml
@@ -1,5 +1,8 @@
 name: Discord Server Setup
 
+permissions:
+  contents: read
+
 # Security Features:
 # - Only repository owner can trigger Discord setup
 # - GLOWBOY token stored securely in GitHub Secrets


### PR DESCRIPTION
Potential fix for [https://github.com/BitPadLabs/GlowStatus/security/code-scanning/2](https://github.com/BitPadLabs/GlowStatus/security/code-scanning/2)

To fix the problem, you should add a `permissions:` key at the root level of the workflow YAML file, before the `jobs:` block. This ensures that the permissions for the `GITHUB_TOKEN` are explicitly set to the minimal required scope for all jobs unless overridden locally. For this workflow, specifying `permissions: contents: read` will restrict the token so that it can only read repository contents, preventing accidental write access.

The changes should be made to `.github/workflows/discord-setup.yml`: add the following block after the workflow's `name:` and before the `on:` trigger:

```yaml
permissions:
  contents: read
```

No imports, methods, or further definitions are necessary as this is a declarative change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
