### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,4 +1,6 @@
 name: Windows Build and Chocolatey Package
+permissions:
+  contents: write
 
 # Security Features:
 # - Only repository owner/maintainers can trigger builds


### PR DESCRIPTION
Potential fix for [https://github.com/BitPadLabs/GlowStatus/security/code-scanning/1](https://github.com/BitPadLabs/GlowStatus/security/code-scanning/1)

To resolve this problem, an explicit `permissions` block must be added at the workflow root (top-level, before jobs:) in `.github/workflows/windows-build.yml` specifying the required permissions for GITHUB_TOKEN. Adding this block ensures the workflow does not inherit unnecessary write permissions—the most minimal block should be `contents: read`, which is sufficient for source code read-only operations. However, since this workflow uploads release artifacts via GitHub Release (`softprops/action-gh-release`), it also needs `contents: write` for tagging/releases and possibly `packages: write` if using the Packages API (but not here). Therefore, the best fix is to add:

```yaml
permissions:
  contents: write
```

directly below `name: ...` and before `on: ...`.  
This will apply this permission to _all_ jobs unless a job further overrides or restricts it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
